### PR TITLE
fix: Increase limit of article categories in CategoryComposer

### DIFF
--- a/app/Http/View/Composers/CategoryComposer.php
+++ b/app/Http/View/Composers/CategoryComposer.php
@@ -18,7 +18,7 @@ class CategoryComposer
         $categories = ArticleCategory::whereHas('articles')
             ->withCount('articles')
             ->orderBy('name')
-            ->limit(4)
+            ->limit(10)
             ->get();
 
         $view->with('articleCategories', $categories);


### PR DESCRIPTION
- Updated the limit of article categories fetched in the CategoryComposer from 4 to 10, allowing for a broader selection of categories to be displayed in the view.