### PR TITLE
feat: Update category selection in CategoryComposer

### DIFF
--- a/app/Http/View/Composers/CategoryComposer.php
+++ b/app/Http/View/Composers/CategoryComposer.php
@@ -15,10 +15,22 @@ class CategoryComposer
      */
     public function compose(View $view)
     {
-        $categories = ArticleCategory::whereHas('articles')
+        // Daftar kategori yang ingin ditampilkan sesuai dengan desain header
+        $desiredCategories = [
+            'MYTHBUSTER', 
+            'SKINCARE',
+            'PERSONALCARE',
+            'HAIRCARE',
+            'DECORATIVE',
+            'MENZONE',
+            'BAHANAKTIF',
+            'BEAUTYLIFE',
+        ];
+
+        $categories = ArticleCategory::whereIn('name', $desiredCategories)
+            ->whereHas('articles')
             ->withCount('articles')
-            ->orderBy('name')
-            ->limit(10)
+            ->orderByRaw("FIELD(name, '" . implode("', '", $desiredCategories) . "')")
             ->get();
 
         $view->with('articleCategories', $categories);


### PR DESCRIPTION
- Modified the CategoryComposer to display a specific set of article categories based on the header design.
- Implemented a filter to fetch categories using the `whereIn` method, ensuring only desired categories are included in the view.